### PR TITLE
Updating cucumber version in Gemfile.lock as test fails with older ve…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'http://rubygems.org'
 
-gem 'cucumber'
+gem 'cucumber', '1.3.18'
 gem 'capybara'
 gem 'selenium-webdriver'
 gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: http://rubygems.org/
   specs:
     browserstack-local (0.1.1)
-    builder (3.2.2)
+    builder (3.2.3)
     capybara (2.2.0)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -11,20 +11,20 @@ GEM
       xpath (~> 2.0)
     childprocess (0.3.9)
       ffi (~> 1.0, >= 1.0.11)
-    cucumber (3.1.2)
+    cucumber (1.3.18)
       builder (>= 2.1.2)
       diff-lcs (>= 1.1.3)
-      gherkin (~> 2.12.0)
-      multi_json (~> 1.7.5)
-      multi_test (~> 0.0.1)
+      gherkin (~> 2.12)
+      multi_json (>= 1.7.5, < 2.0)
+      multi_test (>= 0.1.1)
     diff-lcs (1.2.4)
     ffi (1.9.0)
-    gherkin (2.12.0)
+    gherkin (2.12.2)
       multi_json (~> 1.3)
     mime-types (2.0)
     mini_portile (0.5.2)
     multi_json (1.7.7)
-    multi_test (0.0.1)
+    multi_test (0.1.2)
     nokogiri (1.6.1)
       mini_portile (~> 0.5.0)
     parallel (0.9.1)
@@ -57,10 +57,10 @@ PLATFORMS
 DEPENDENCIES
   browserstack-local
   capybara
-  cucumber
+  cucumber (= 1.3.18)
   parallel_tests
   rspec
   selenium-webdriver
 
 BUNDLED WITH
-   1.11.2
+   1.16.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GEM
       xpath (~> 2.0)
     childprocess (0.3.9)
       ffi (~> 1.0, >= 1.0.11)
-    cucumber (1.3.4)
+    cucumber (3.1.2)
       builder (>= 2.1.2)
       diff-lcs (>= 1.1.3)
       gherkin (~> 2.12.0)


### PR DESCRIPTION
Updating cucumber version in Gemfile.lock as test fails with older version cucumber with message '/usr/local/lib/ruby/gems/2.5.0/gems/cucumber-1.3.4/lib/cucumber/ast/step.rb:80: warning: circular argument reference - name'. Updating cucumber version as per suggestions here https://github.com/cucumber/cucumber-ruby/issues/781#issuecomment-68163319